### PR TITLE
dark/light returning wrong value, fix order of operations

### DIFF
--- a/color.js
+++ b/color.js
@@ -170,7 +170,7 @@ Color.prototype = {
    dark: function() {
       // YIQ equation from http://24ways.org/2010/calculating-color-contrast
       var rgb = this.values.rgb,
-          yiq = rgb[0] * 299 + rgb[1] * 587 + rgb[2] * 114 / 1000;
+          yiq = (rgb[0] * 299 + rgb[1] * 587 + rgb[2] * 114) / 1000;
    	return yiq < 128;
    },
    


### PR DESCRIPTION
dark/light weren't returning the correct value due to incorrect order of operations
