### PR TITLE
Teach mix() to allow 0 weight

### DIFF
--- a/color.js
+++ b/color.js
@@ -239,7 +239,7 @@ Color.prototype = {
    },
    
    mix: function(color2, weight) {
-      weight = 1 - (weight || 0.5);
+      weight = 1 - (weight == null ? 0.5 : weight);
       
       // algorithm from Sass's mix(). Ratio of first color in mix is
       // determined by the alphas of both colors and the weight


### PR DESCRIPTION
It seems that `myColor.mix(otherColor, 0)` should return `myColor`. Right now, it evaluates 0 as falsy, and turns `weight` into `0.5`

Thanks for the lib! It's certainly coming in handy.
