### PR TITLE
fixed bug preventing setting alpha value to 0

### DIFF
--- a/color.js
+++ b/color.js
@@ -320,7 +320,7 @@ Color.prototype.setValues = function(space, vals) {
       }
       alpha = vals.alpha;
    }
-   this.values.alpha = Math.max(0, Math.min(1, alpha || this.values.alpha));
+   this.values.alpha = Math.max(0, Math.min(1, (alpha !== undefined ? alpha : this.values.alpha) ));
    if (space == "alpha") {
       return;
    }


### PR DESCRIPTION
example:
var color = Color('#ABC').alpha(0);
color.values.alpha // returns 1 when it should have been set to 0
