### PR TITLE
Add `clone()` function to create a copy of the color object

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,14 @@ color.mix(Color("yellow"))   // cyan -> rgb(128, 255, 128)
 color.green(100).greyscale().lighten(0.6)
 ```
 
+### Clone
+
+You can can create a copy of an existing color object using `clone()`:
+
+```javascript
+color.clone() // -> New color object
+```
+
 And more to come...
 
 ## Propers

--- a/color.js
+++ b/color.js
@@ -264,7 +264,11 @@ Color.prototype = {
 
    toJSON: function() {
      return this.rgb();
-   }
+   },
+
+   clone: function() {
+     return new Color(this.rgb());
+   },
 }
 
 

--- a/test/basic.js
+++ b/test/basic.js
@@ -128,3 +128,9 @@ assert.deepEqual(Color("yellow").mix(Color("grey")).rgbArray(), [192, 192, 64]);
 assert.deepEqual(Color("yellow").mix(Color("grey"), 1).rgbArray(), [128, 128, 128]);
 assert.deepEqual(Color("yellow").mix(Color("grey"), 0.8).rgbArray(), [153, 153, 102]);
 assert.deepEqual(Color("yellow").mix(Color("grey").alpha(0.5)).rgbaArray(), [223, 223, 32, 0.75]);
+
+// Clone
+var clone = Color({r: 10, g: 20, b: 30});
+assert.deepEqual(clone.rgbaArray(), [10, 20, 30, 1]);
+assert.deepEqual(clone.clone().rgb(50, 40, 30).rgbaArray(), [50, 40, 30, 1]);
+assert.deepEqual(clone.rgbaArray(), [10, 20, 30, 1]);


### PR DESCRIPTION
I needed to create a copy of an existing color so that I can manipulate it to create a new color but still leave the original base color alone so that it can be used again later. I added a `color.clone()` function to return a new color object with the same values as the original.

This function uses `this.rgb()` to "serialize" the color object and pass it to the Color constructor to create a new color object with values equal to the original.

The new function is documented in the readme.

There are tests to make sure the values of the cloned object match the original and that if the cloned object is manipulated the original object does not change.
