### PR TITLE
Added example for 'mix' method with weight param

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,8 @@ color.opaquer(0.5)     // rgba(10, 10, 10, 0.8) -> rgba(10, 10, 10, 1.0)
 color.rotate(180)      // hsl(60, 20%, 20%) -> hsl(240, 20%, 20%)
 color.rotate(-90)      // hsl(60, 20%, 20%) -> hsl(330, 20%, 20%)
 
-color.mix(Color("yellow"))   // cyan -> rgb(128, 255, 128)
+color.mix(Color("yellow"))        // cyan -> rgb(128, 255, 128)
+color.mix(Color("yellow"), 0.3)   // cyan -> rgb(77, 255, 179)
 
 // chaining
 color.green(100).greyscale().lighten(0.6)


### PR DESCRIPTION
I was going to keep using some my old method (functionality of which I did not find in your lib). But after digging in source code for another reason I noticed that 'mix' method has 2 params, and 2nd is optional. After playing a bit with it I realized that 'mix' method does exactly same as my method, but in a bit different manner.

I think would be nice to let users know about 2nd param without digging into sources
