### PR TITLE
Add hwb() + fix max for hue

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ var color = Color("#7743CE");
 color.alpha(0.5).lighten(0.5);
 
 console.log(color.hslString());  // "hsla(262, 59%, 81%, 0.5)"
-```	
+```
 
 ## Install
 
@@ -33,12 +33,12 @@ var color = Color({r: 255, g: 255, b: 255})
 var color = Color().rgb(255, 255, 255)
 var color = Color().rgb([255, 255, 255])
 ```
-Pass any valid CSS color string into `Color()` or a hash of values. Also load in color values with `rgb()`, `hsl()`, `hsv()`,and `cmyk()`.
+Pass any valid CSS color string into `Color()` or a hash of values. Also load in color values with `rgb()`, `hsl()`, `hsv()`, `hwb()`, and `cmyk()`.
 
 ```javascript
 color.red(120)
 ```
-Set the values for individual channels with `alpha`, `red`, `green`, `blue`, `hue`, `saturation` (hsl), `saturationv` (hsv), `lightness`, `cyan`, `magenta`, `yellow`, `black`
+Set the values for individual channels with `alpha`, `red`, `green`, `blue`, `hue`, `saturation` (hsl), `saturationv` (hsv), `lightness`, `whiteness`, `blackness`, `cyan`, `magenta`, `yellow`, `black`
 
 ### Getters
 
@@ -64,7 +64,7 @@ Get the value for an individual channel.
 color.hslString()  // "hsl(320, 50%, 100%)"
 ```
 
-Different CSS String formats for the color are on `hexString`, `rgbString`, `percentString`, `hslString`, and `keyword` (undefined if it's not a keyword color). `"rgba"` and `"hsla"` are used if the current alpha value of the color isn't `1`.
+Different CSS String formats for the color are on `hexString`, `rgbString`, `percentString`, `hslString`, `hwbString`, and `keyword` (undefined if it's not a keyword color). `"rgba"` and `"hsla"` are used if the current alpha value of the color isn't `1`.
 
 ### Luminosity
 
@@ -95,6 +95,9 @@ color.darken(0.5)      // hsl(100, 50%, 50%) -> hsl(100, 50%, 25%)
 color.saturate(0.5)    // hsl(100, 50%, 50%) -> hsl(100, 75%, 50%)
 color.desaturate(0.5)  // hsl(100, 50%, 50%) -> hsl(100, 25%, 50%)
 color.greyscale()      // #5CBF54 -> #969696
+
+color.whiten(0.5)      // hwb(100, 50%, 50%) -> hwb(100, 75%, 50%)
+color.blacken(0.5)     // hwb(100, 50%, 50%) -> hwb(100, 50%, 75%)
 
 color.clearer(0.5)     // rgba(10, 10, 10, 0.8) -> rgba(10, 10, 10, 0.4)
 color.opaquer(0.5)     // rgba(10, 10, 10, 0.8) -> rgba(10, 10, 10, 1.0)

--- a/color.js
+++ b/color.js
@@ -11,6 +11,7 @@ var Color = function(cssString) {
       rgb: [0, 0, 0],
       hsl: [0, 0, 0],
       hsv: [0, 0, 0],
+      hwb: [0, 0, 0],
       cmyk: [0, 0, 0, 0],
       alpha: 1
    }
@@ -24,6 +25,9 @@ var Color = function(cssString) {
       else if(vals = string.getHsla(cssString)) {
          this.setValues("hsl", vals);
       }
+      else if(vals = string.getHwb(cssString)) {
+         this.setValues("hwb", vals);
+      }
    }
    else if (typeof cssString == "object") {
       var vals = cssString;
@@ -35,6 +39,9 @@ var Color = function(cssString) {
       }
       else if(vals["v"] !== undefined || vals["value"] !== undefined) {
          this.setValues("hsv", vals)
+      }
+      else if(vals["w"] !== undefined || vals["whiteness"] !== undefined) {
+         this.setValues("hwb", vals)
       }
       else if(vals["c"] !== undefined || vals["cyan"] !== undefined) {
          this.setValues("cmyk", vals)
@@ -52,6 +59,9 @@ Color.prototype = {
    hsv: function(vals) {
       return this.setSpace("hsv", arguments);
    },
+   hwb: function(vals) {
+      return this.setSpace("hwb", arguments);
+   },
    cmyk: function(vals) {
       return this.setSpace("cmyk", arguments);
    },
@@ -65,6 +75,12 @@ Color.prototype = {
    hsvArray: function() {
       return this.values.hsv;
    },
+   hwbArray: function() {
+      if (this.values.alpha !== 1) {
+        return this.values.hwb.concat([this.values.alpha])
+      }
+      return this.values.hwb;
+   },
    cmykArray: function() {
       return this.values.cmyk;
    },
@@ -76,7 +92,6 @@ Color.prototype = {
       var hsl = this.values.hsl;
       return hsl.concat([this.values.alpha]);
    },
-
    alpha: function(val) {
       if (val === undefined) {
          return this.values.alpha;
@@ -105,6 +120,12 @@ Color.prototype = {
    },
    saturationv: function(val) {
       return this.setChannel("hsv", 1, val);
+   },
+   whiteness: function(val) {
+      return this.setChannel("hwb", 1, val);
+   },
+   blackness: function(val) {
+      return this.setChannel("hwb", 2, val);
    },
    value: function(val) {
       return this.setChannel("hsv", 2, val);
@@ -139,6 +160,9 @@ Color.prototype = {
    },
    hslaString: function() {
       return string.hslaString(this.values.hsl, this.values.alpha);
+   },
+   hwbString: function() {
+      return string.hwbString(this.values.hwb, this.values.alpha);
    },
    keyword: function() {
       return string.keyword(this.values.rgb, this.values.alpha);
@@ -216,6 +240,18 @@ Color.prototype = {
    desaturate: function(ratio) {
       this.values.hsl[1] -= this.values.hsl[1] * ratio;
       this.setValues("hsl", this.values.hsl);
+      return this;
+   },
+
+   whiten: function(ratio) {
+      this.values.hwb[1] += this.values.hwb[1] * ratio;
+      this.setValues("hwb", this.values.hwb);
+      return this;
+   },
+
+   blacken: function(ratio) {
+      this.values.hwb[2] += this.values.hwb[2] * ratio;
+      this.setValues("hwb", this.values.hwb);
       return this;
    },
 
@@ -298,13 +334,15 @@ Color.prototype.setValues = function(space, vals) {
       "rgb": ["red", "green", "blue"],
       "hsl": ["hue", "saturation", "lightness"],
       "hsv": ["hue", "saturation", "value"],
+      "hwb": ["hue", "whiteness", "blackness"],
       "cmyk": ["cyan", "magenta", "yellow", "black"]
    };
 
    var maxes = {
       "rgb": [255, 255, 255],
-      "hsl": [359, 100, 100],
-      "hsv": [359, 100, 100],
+      "hsl": [360, 100, 100],
+      "hsv": [360, 100, 100],
+      "hwb": [360, 100, 100],
       "cmyk": [100, 100, 100, 100]
    };
 

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
   },
   "main": "./color",
   "dependencies": {
-    "color-convert": "0.2.x",
-    "color-string": "0.1.x"
+    "color-convert": "0.4.x",
+    "color-string": "0.2.x"
   },
   "devDependencies": {
     "nomnom": "~1.5.2",

--- a/test/basic.js
+++ b/test/basic.js
@@ -10,15 +10,19 @@ assert.deepEqual(Color("rgba(4%, 12%, 10%, 0.4)").rgb(), {r: 10, g: 31, b: 26, a
 assert.deepEqual(Color("blue").rgb(), {r: 0, g: 0, b: 255});
 assert.deepEqual(Color("hsl(120, 50%, 60%)").hsl(), {h: 120, s: 50, l: 60});
 assert.deepEqual(Color("hsla(120, 50%, 60%, 0.4)").hsl(), {h: 120, s: 50, l: 60, a: 0.4});
+assert.deepEqual(Color("hwb(120, 50%, 60%)").hwb(), {h: 120, w: 50, b: 60});
+assert.deepEqual(Color("hwb(120, 50%, 60%, 0.4)").hwb(), {h: 120, w: 50, b: 60, a: 0.4});
 
 assert.deepEqual(Color({r: 10, g: 30, b: 25}).rgb(), {r: 10, g: 30, b: 25});
 assert.deepEqual(Color({h: 10, s: 30, l: 25}).hsl(), {h: 10, s: 30, l: 25});
 assert.deepEqual(Color({h: 10, s: 30, v: 25}).hsv(), {h: 10, s: 30, v: 25});
+assert.deepEqual(Color({h: 10, w: 30, b: 25}).hwb(), {h: 10, w: 30, b: 25});
 assert.deepEqual(Color({c: 10, m: 30, y: 25, k: 10}).cmyk(), {c: 10, m: 30, y: 25, k: 10});
 
 assert.deepEqual(Color({red: 10, green: 30, blue: 25}).rgb(), {r: 10, g: 30, b: 25});
 assert.deepEqual(Color({hue: 10, saturation: 30, lightness: 25}).hsl(), {h: 10, s: 30, l: 25});
 assert.deepEqual(Color({hue: 10, saturation: 30, value: 25}).hsv(), {h: 10, s: 30, v: 25});
+assert.deepEqual(Color({hue: 10, whiteness: 30, blackness: 25}).hwb(), {h: 10, w: 30, b: 25});
 assert.deepEqual(Color({cyan: 10, magenta: 30, yellow: 25, black: 10}).cmyk(), {c: 10, m: 30, y: 25, k: 10});
 
 // Setters
@@ -33,6 +37,7 @@ assert.deepEqual(Color().rgb({red: 10, green: 30, blue: 25, alpha: 0.4}).rgb(), 
 
 assert.deepEqual(Color().hsl([260, 10, 10]).hsl(), {h: 260, s: 10, l: 10});
 assert.deepEqual(Color().hsv([260, 10, 10]).hsv(), {h: 260, s: 10, v: 10});
+assert.deepEqual(Color().hwb([260, 10, 10]).hwb(), {h: 260, w: 10, b: 10});
 assert.deepEqual(Color().cmyk([10, 10, 10, 10]).cmyk(), {c: 10, m: 10, y: 10, k: 10});
 
 // retain alpha
@@ -42,12 +47,14 @@ assert.equal(Color().rgb([10, 30, 25, 0.4]).rgb([10, 30, 25]).alpha(), 0.4);
 assert.deepEqual(Color().rgb(10, 30, 25).rgb(), {r: 10, g: 30, b: 25});
 assert.deepEqual(Color().rgb(10, 30, 25).hsl(), {h: 165, s: 50, l: 8});
 assert.deepEqual(Color().rgb(10, 30, 25).hsv(), {h: 165, s: 67, v: 12});
+assert.deepEqual(Color().rgb(10, 30, 25).hwb(), {h: 165, w: 4, b: 88});
 assert.deepEqual(Color().rgb(10, 30, 25).cmyk(), {c: 67, m: 0, y: 17, k: 88});
 
 // Array getters
 assert.deepEqual(Color({r: 10, g: 20, b: 30}).rgbArray(), [10, 20, 30]);
 assert.deepEqual(Color({h: 10, s: 20, l: 30}).hslArray(), [10, 20, 30]);
 assert.deepEqual(Color({h: 10, s: 20, v: 30}).hsvArray(), [10, 20, 30]);
+assert.deepEqual(Color({h: 10, w: 20, b: 30}).hwbArray(), [10, 20, 30]);
 assert.deepEqual(Color({c: 10, m: 20, y: 30, k: 40}).cmykArray(), [10, 20, 30, 40]);
 
 // Multiple times
@@ -66,11 +73,18 @@ assert.equal(Color({r: 10, g: 20, b: 30}).blue(), 30);
 assert.equal(Color({r: 10, g: 20, b: 30}).blue(60).blue(), 60);
 assert.equal(Color({h: 10, s: 20, l: 30}).hue(), 10);
 assert.equal(Color({h: 10, s: 20, l: 30}).hue(100).hue(), 100);
+assert.equal(Color({h: 10, w: 20, b: 30}).hue(), 10);
+assert.equal(Color({h: 10, w: 20, b: 30}).hue(100).hue(), 100);
 
 // Capping values
-assert.equal(Color({h: 400, s: 50, l: 10}).hue(), 359);
+assert.equal(Color({h: 400, s: 50, l: 10}).hue(), 360);
 assert.equal(Color({h: 100, s: 50, l: 80}).lighten(0.5).lightness(), 100);
 assert.equal(Color({h: -400, s: 50, l: 10}).hue(), 0);
+
+assert.equal(Color({h: 400, w: 50, b: 10}).hue(), 0); // 0 == 360
+assert.equal(Color({h: 100, w: 50, b: 80}).blacken(0.5).blackness(), 100);
+assert.equal(Color({h: -400, w: 50, b: 10}).hue(), 0);
+
 assert.equal(Color().red(400).red(), 255);
 assert.equal(Color().red(-400).red(), 0);
 assert.equal(Color().rgb(10, 10, 10, 12).alpha(), 1);
@@ -90,6 +104,8 @@ assert.equal(Color("rgb(10, 30, 25)").percentString(), "rgb(4%, 12%, 10%)")
 assert.equal(Color("rgb(10, 30, 25, 0.3)").percentString(), "rgba(4%, 12%, 10%, 0.3)")
 assert.equal(Color("rgb(10, 30, 25)").hslString(), "hsl(165, 50%, 8%)")
 assert.equal(Color("rgb(10, 30, 25, 0.3)").hslString(), "hsla(165, 50%, 8%, 0.3)")
+assert.equal(Color("rgb(10, 30, 25)").hwbString(), "hwb(165, 4%, 88%)")
+assert.equal(Color("rgb(10, 30, 25, 0.3)").hwbString(), "hwb(165, 4%, 88%, 0.3)")
 assert.equal(Color("rgb(0, 0, 255)").keyword(), "blue")
 assert.strictEqual(Color("rgb(10, 30, 25)").keyword(), undefined)
 
@@ -116,6 +132,8 @@ assert.deepEqual(Color({r: 67, g: 122, b: 134}).greyscale().rgb(), {r: 107, g: 1
 assert.deepEqual(Color({r: 67, g: 122, b: 134}).negate().rgb(), {r: 188, g: 133, b: 121});
 assert.equal(Color({h: 100, s: 50, l: 60}).lighten(0.5).lightness(), 90);
 assert.equal(Color({h: 100, s: 50, l: 60}).darken(0.5).lightness(), 30);
+assert.equal(Color({h: 100, w: 50, b: 60}).whiten(0.5).whiteness(), 75);
+assert.equal(Color({h: 100, w: 50, b: 60}).blacken(0.5).blackness(), 90);
 assert.equal(Color({h: 100, s: 40, l: 50}).saturate(0.5).saturation(), 60);
 assert.equal(Color({h: 100, s: 80, l: 60}).desaturate(0.5).saturation(), 40);
 assert.equal(Color({r: 10, g: 10, b: 10, a: 0.8}).clearer(0.5).alpha(), 0.4);
@@ -138,4 +156,3 @@ assert.deepEqual(clone.rgbaArray(), [10, 20, 30, 1]);
 // Level
 assert.equal(Color("white").level(Color("black")), "AAA");
 assert.equal(Color("grey").level(Color("black")), "AA");
-


### PR DESCRIPTION
Following

harthur/color-string#8
harthur/color-convert#10

+

capping must be done before convert loop for each spaces.
Otherwise it’s not coherent with how color-convert handle overflow
(modulo).

Ref #24
