### PR TITLE
Throw exception when color can't be parsed

### DIFF
--- a/color.js
+++ b/color.js
@@ -28,6 +28,9 @@ var Color = function(cssString) {
       else if(vals = string.getHwb(cssString)) {
          this.setValues("hwb", vals);
       }
+      else {
+        throw new Error("Unable to parse color from string " + cssString);
+      }
    }
    else if (typeof cssString == "object") {
       var vals = cssString;
@@ -45,6 +48,9 @@ var Color = function(cssString) {
       }
       else if(vals["c"] !== undefined || vals["cyan"] !== undefined) {
          this.setValues("cmyk", vals)
+      }
+      else {
+        throw new Error("Unable to parse color from object " + JSON.stringify(cssString));
       }
    }
 }

--- a/test/basic.js
+++ b/test/basic.js
@@ -156,3 +156,12 @@ assert.deepEqual(clone.rgbaArray(), [10, 20, 30, 1]);
 // Level
 assert.equal(Color("white").level(Color("black")), "AAA");
 assert.equal(Color("grey").level(Color("black")), "AA");
+
+// Exceptions
+assert.throws(function () {
+  Color("unknow")
+}, /Unable to parse color from string/);
+
+assert.throws(function () {
+  Color({})
+}, /Unable to parse color from object/);


### PR DESCRIPTION
Before this commit, when I try to parse “rebeccapurple” ([ref](https://github.com/jonathanKingston/rework-rebeccapurple#explanation)) I get rgb(0,0,0) & don’t know if it’s really black or just an unknown value.

It will help us to ignore unknown values in [css-color-function](https://github.com/ianstormtaylor/css-color-function) & don’t return wrong value instead.
