### PR TITLE
Allow access to Color class

### DIFF
--- a/color.js
+++ b/color.js
@@ -2,11 +2,10 @@
 var convert = require("color-convert"),
     string = require("color-string");
 
-module.exports = function(cssString) {
-   return new Color(cssString);
-};
-
 var Color = function(cssString) {
+  if (cssString instanceof Color) return cssString;
+  if (! (this instanceof Color)) return new Color(cssString);
+
    this.values = {
       rgb: [0, 0, 0],
       hsl: [0, 0, 0],
@@ -426,3 +425,5 @@ Color.prototype.setChannel = function(space, index, val) {
    this.setValues(space, this.values[space]);
    return this;
 }
+
+module.exports = Color;


### PR DESCRIPTION
This exports the `Color`class, so that users can create their own methods on the prototype.

It's backwards compatible and doesn't break any of the tests.

Example usage:

``` javascript
var Color = require('color');

Color.prototype.averagedRgbArray = function () {
  return this.rgbArray().map(function (val) {
    return val / 255
  });
};

var color = new Color({r: 20, g: 60, b: 100});
console.log(color); // [ 0.0784, 0.235, 0.392 ]
```
