### PR TITLE
Make color instance be a real instance

### DIFF
--- a/color.js
+++ b/color.js
@@ -2,11 +2,15 @@
 var convert = require("color-convert"),
     string = require("color-string");
 
-module.exports = function(cssString) {
-   return new Color(cssString);
-};
+module.exports = Color;
 
-var Color = function(cssString) {
+function Color(cssString) {
+   //prevent double init
+   if (cssString instanceof Color) return cssString;
+
+   //force new 
+   if (!this || this.constructor !== Color) return new Color(cssString);
+
    this.values = {
       rgb: [0, 0, 0],
       hsl: [0, 0, 0],
@@ -14,7 +18,7 @@ var Color = function(cssString) {
       hwb: [0, 0, 0],
       cmyk: [0, 0, 0, 0],
       alpha: 1
-   }
+   };
 
    // parse Color() argument
    if (typeof cssString == "string") {
@@ -56,6 +60,8 @@ var Color = function(cssString) {
 }
 
 Color.prototype = {
+   constructor: Color,
+
    rgb: function (vals) {
       return this.setSpace("rgb", arguments);
    },


### PR DESCRIPTION
For now `(new Color) instanceof Color === false`, which makes unavailable Color instance detection.
The patch fixes this issue as well as adds detection of `Color` instance as an input argument.
All tests passes.

Please also update _color-convert_ dependency due to this PR: https://github.com/harthur/color-convert/pull/11.

I am going to use Color within [picky.js](https://github.com/dfcreative/picky) as a color model and this issue blocks normal way of making things.
