### PR TITLE
add test for cloning empty color

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -713,6 +713,23 @@ it('Clone', function () {
 	deepEqual(clone.rgbaArray(), [10, 20, 30, 1]);
 });
 
+it('Clone: default constructor', function () {
+	var defaultColor = Color();
+	var clonedFromDefault = defaultColor.clone();
+
+	// same tests used in base case 'Clone'
+	deepEqual(defaultColor.rgbaArray(), [0, 0, 0, 1]);
+	deepEqual(defaultColor.clone().rgb(0, 0, 0).rgbaArray(), [0, 0, 0, 1]);
+	deepEqual(defaultColor.rgbaArray(), [0, 0, 0, 1]);
+
+	// additional checks
+	deepEqual(clonedFromDefault.rgbaArray(), [0, 0, 0, 1]);
+	equal(
+		defaultColor.hwbString(),
+		clonedFromDefault.hwbString()
+	);
+});
+
 it('Level', function () {
 	equal(Color('white').level(Color('black')), 'AAA');
 	equal(Color('grey').level(Color('black')), 'AA');

--- a/test/index.js
+++ b/test/index.js
@@ -7,6 +7,7 @@ var deepEqual = assert.deepEqual;
 var equal = assert.equal;
 var ok = assert.ok;
 var strictEqual = assert.strictEqual;
+var notStrictEqual = assert.notStrictEqual;
 var throws = assert.throws;
 
 it('Color() instance', function () {
@@ -708,6 +709,7 @@ it('Clone', function () {
 		g: 20,
 		b: 30
 	});
+	notStrictEqual(clone, clone.clone());
 	deepEqual(clone.rgbaArray(), [10, 20, 30, 1]);
 	deepEqual(clone.clone().rgb(50, 40, 30).rgbaArray(), [50, 40, 30, 1]);
 	deepEqual(clone.rgbaArray(), [10, 20, 30, 1]);
@@ -718,6 +720,7 @@ it('Clone: default constructor', function () {
 	var clonedFromDefault = defaultColor.clone();
 
 	// same tests used in base case 'Clone'
+	notStrictEqual(defaultColor, clonedFromDefault);
 	deepEqual(defaultColor.rgbaArray(), [0, 0, 0, 1]);
 	deepEqual(defaultColor.clone().rgb(0, 0, 0).rgbaArray(), [0, 0, 0, 1]);
 	deepEqual(defaultColor.rgbaArray(), [0, 0, 0, 1]);


### PR DESCRIPTION
Shows issue 67 is already fixed (by commit 5b625b3abacb514cabb8f77395da71259a4aa348).

That hash is for the commit that adds immutability. Adding this test should prevent a regression (although I assume cloning might be removed at some point since it seems pointless with an immutable API).