### PR TITLE
Added standalone build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+standalone_dist
 node_modules

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,1 @@
+node_modules

--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
     "index.js"
   ],
   "scripts": {
+    "prepublish": "npm run build",
+    "build": "webpack",
     "pretest": "xo",
     "test": "mocha"
   },
@@ -35,6 +37,7 @@
   },
   "devDependencies": {
     "mocha": "^2.2.5",
+    "webpack": "^1.12.13",
     "xo": "^0.12.1"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,26 +2,26 @@ var webpack = require('webpack');
 var path = require('path');
 
 module.exports = {
-  entry: path.join(__dirname, 'index'),
-  output: {
-    path: path.join(__dirname, 'standalone_dist'),
-    filename: 'color.min.js',
-    library: 'Color',
-    libraryTarget: 'umd'
-  },
-  plugins: [
-    new webpack.optimize.DedupePlugin(),
-    new webpack.optimize.OccurenceOrderPlugin(),
-    new webpack.optimize.UglifyJsPlugin({
-      compress: {
-        warnings: false
-      }
-    }),
-    new webpack.DefinePlugin({
-      'process.env.NODE_ENV': JSON.stringify('production')
-    })
-  ],
-  resolve: {
-    extensions: ['', '.js']
-  }
+	entry: path.join(__dirname, 'index'),
+	output: {
+		path: path.join(__dirname, 'standalone_dist'),
+		filename: 'color.min.js',
+		library: 'Color',
+		libraryTarget: 'umd'
+	},
+	plugins: [
+		new webpack.optimize.DedupePlugin(),
+		new webpack.optimize.OccurenceOrderPlugin(),
+		new webpack.optimize.UglifyJsPlugin({
+			compress: {
+				warnings: false
+			}
+		}),
+		new webpack.DefinePlugin({
+			'process.env.NODE_ENV': JSON.stringify('production')
+		})
+	],
+	resolve: {
+		extensions: ['', '.js']
+	}
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,27 @@
+var webpack = require('webpack');
+var path = require('path');
+
+module.exports = {
+  entry: path.join(__dirname, 'index'),
+  output: {
+    path: path.join(__dirname, 'standalone_dist'),
+    filename: 'color.min.js',
+    library: 'Color',
+    libraryTarget: 'umd'
+  },
+  plugins: [
+    new webpack.optimize.DedupePlugin(),
+    new webpack.optimize.OccurenceOrderPlugin(),
+    new webpack.optimize.UglifyJsPlugin({
+      compress: {
+        warnings: false
+      }
+    }),
+    new webpack.DefinePlugin({
+      'process.env.NODE_ENV': JSON.stringify('production')
+    })
+  ],
+  resolve: {
+    extensions: ['', '.js']
+  }
+};


### PR DESCRIPTION
Hi! I want this lib to be accessible via just a script tag so I've added a webpack-build. I haven't changed where the 'main' is pointing out, so `require('color')` will still be delivering index.js from the root of the package, but at the same time one would be able to access the lib via `https://npmcdn.com/color/standalone_dist/color.min.js` (and also via cdnjs, cdnjs/cdnjs#6800).