### PR TITLE
Fix Travis badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# color [![Build Status](https://travis-ci.org/MoOx/color.svg?branch=master)](https://travis-ci.org/MoOx/color)
+# color [![Build Status](https://travis-ci.org/Qix-/color.svg?branch=master)](https://travis-ci.org/Qix-/color)
 
 > JavaScript library for color conversion and manipulation with support for CSS color strings.
 


### PR DESCRIPTION
It seems the ownership changed ?
Right now, there is a blank image instead of the Travis badge, and "The repository at MoOx/color was not found."