### PR TITLE
Make toString() return rgbaString()

### DIFF
--- a/index.js
+++ b/index.js
@@ -173,6 +173,9 @@ Color.prototype = {
 	keyword: function () {
 		return string.keyword(this.values.rgb, this.values.alpha);
 	},
+	toString: function () {
+		return this.rgbaString();
+	},
 
 	rgbNumber: function () {
 		return (this.values.rgb[0] << 16) | (this.values.rgb[1] << 8) | this.values.rgb[2];

--- a/test/index.js
+++ b/test/index.js
@@ -679,6 +679,11 @@ it('Mix: alpha', function () {
 	equal(Color('rgba(255, 0, 0, 0.5)').mix(Color('#00f')).rgbaString(), 'rgba(64, 0, 191, 0.75)');
 });
 
+it('toString() is alias for rgbaString()', function () {
+	var color = Color('red').lighten('20%');
+	equal(color.clone().toString(), color.clone().rgbaString());
+});
+
 it('Mix: 50%', function () {
 	equal(Color('#f00').mix(Color('#00f'), 0.5).hexString(), '#800080');
 });


### PR DESCRIPTION
This is a breaking change (`toString` used to return `[object Object]`), but it makes the library a lot easier to use. 

Almost all of the time, I don't care what type of color it gives me in the end. I only care that I get a valid CSS color string.

``` js
var style = {
  backgroundColor: String(Color('red').alpha(0.5))
}
```
