### PR TITLE
Update to color-convert @ 1.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "clone": "^1.0.2",
-    "color-convert": "^0.5.3",
+    "color-convert": "^1.3.0",
     "color-string": "^0.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
color-convert didn't have a license declared prior to version 1, so it would be great to update the dependency to the current version.

We only use the `convert.rgb.hsl(140, 200, 100); ` API which hasn't been changed

Once merged, can you please publish a new version to npm ?

