### PR TITLE
fix cloning

### DIFF
--- a/index.js
+++ b/index.js
@@ -321,7 +321,7 @@ Color.prototype = {
 
 	clone: function () {
 		var col = new Color();
-		col.values = clone(col.values);
+		col.values = clone(this.values);
 		return col;
 	}
 };

--- a/test/index.js
+++ b/test/index.js
@@ -699,6 +699,7 @@ it('Clone', function () {
 	});
 	notStrictEqual(clone, clone.clone());
 	deepEqual(clone.rgbaArray(), [10, 20, 30, 1]);
+	deepEqual(clone.clone().rgbaArray(), [10, 20, 30, 1]);
 	deepEqual(clone.clone().rgb(50, 40, 30).rgbaArray(), [50, 40, 30, 1]);
 	deepEqual(clone.rgbaArray(), [10, 20, 30, 1]);
 });
@@ -710,6 +711,7 @@ it('Clone: default constructor', function () {
 	// same tests used in base case 'Clone'
 	notStrictEqual(defaultColor, clonedFromDefault);
 	deepEqual(defaultColor.rgbaArray(), [0, 0, 0, 1]);
+	deepEqual(defaultColor.clone().rgbaArray(), [0, 0, 0, 1]);
 	deepEqual(defaultColor.clone().rgb(0, 0, 0).rgbaArray(), [0, 0, 0, 1]);
 	deepEqual(defaultColor.rgbaArray(), [0, 0, 0, 1]);
 


### PR DESCRIPTION
Hey,

as of version 0.11.2 the clone method is behaving different to prior versions.

Currently it just creates a new default color object. This pull requests fixes the issue.