### PR TITLE
Address the floating point number precision issue of JavaScript

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,10 @@ var clone = require('clone');
 var convert = require('color-convert');
 var string = require('color-string');
 
+function fixFloatPrecision(number) {
+	return parseFloat(number.toFixed(8));
+}
+
 var Color = function (obj) {
 	if (obj instanceof Color) {
 		return obj;
@@ -153,25 +157,25 @@ Color.prototype = {
 		return string.hexString(this.values.rgb);
 	},
 	rgbString: function () {
-		return string.rgbString(this.values.rgb, this.values.alpha);
+		return string.rgbString(this.values.rgb, fixFloatPrecision(this.values.alpha));
 	},
 	rgbaString: function () {
-		return string.rgbaString(this.values.rgb, this.values.alpha);
+		return string.rgbaString(this.values.rgb, fixFloatPrecision(this.values.alpha));
 	},
 	percentString: function () {
-		return string.percentString(this.values.rgb, this.values.alpha);
+		return string.percentString(this.values.rgb, fixFloatPrecision(this.values.alpha));
 	},
 	hslString: function () {
-		return string.hslString(this.values.hsl, this.values.alpha);
+		return string.hslString(this.values.hsl, fixFloatPrecision(this.values.alpha));
 	},
 	hslaString: function () {
-		return string.hslaString(this.values.hsl, this.values.alpha);
+		return string.hslaString(this.values.hsl, fixFloatPrecision(this.values.alpha));
 	},
 	hwbString: function () {
-		return string.hwbString(this.values.hwb, this.values.alpha);
+		return string.hwbString(this.values.hwb, fixFloatPrecision(this.values.alpha));
 	},
 	keyword: function () {
-		return string.keyword(this.values.rgb, this.values.alpha);
+		return string.keyword(this.values.rgb, fixFloatPrecision(this.values.alpha));
 	},
 
 	rgbNumber: function () {

--- a/test/index.js
+++ b/test/index.js
@@ -647,6 +647,12 @@ it('Manipulators wo/ mix', function () {
 		r: 10,
 		g: 10,
 		b: 10,
+		a: 1
+	}).clearer(0.8).rgbaString(), 'rgba(10, 10, 10, 0.2)');
+	equal(Color({
+		r: 10,
+		g: 10,
+		b: 10,
 		a: 0.8
 	}).clearer(0.5).alpha(), 0.4);
 	equal(Color({


### PR DESCRIPTION
Due to the [floating-point issue of JavaScript](http://stackoverflow.com/questions/1458633/how-to-deal-with-floating-point-number-precision-in-javascript), `color` sometime generates really odd color strings like "`rgba(10, 10, 10, 0.19999999999999996)`". This is not an issue in most situations, generally. But there are tiny differences of the results from different browsers. For example:

``` javascript
alert(1.0 - 0.8)
# in IE11, it outputs 0.19999999999999995
# in Chrome and others, it outputs 0.19999999999999996
```

This is also not a big deal if the results are not required to be exactly identical. But I have run into a case that the results output by `color` are participated in a checksum verification and it causes troubles in certain browser(s) like below:

```
(Console output from Internet Explorer 11)
Warning: React attempted to reuse markup in a container but the checksum was invalid. This generally means that you are using server rendering and the markup generated on the server was not what the client was expecting. React injected new markup to compensate which works but you have lost many of the benefits of server rendering. Instead, figure out why the markup being generated is different on the client or server:
 (client) , 0.19999999999999995);}.btn:hover:not(:
 (server) , 0.19999999999999996);}.btn:hover:not(:
```

Since the toolchain I used is also used by many frontend developers, this may not be just a rare case. I managed to make a workaround with `toFixed` and `parseFloat` to fix the string output. And all tests are passed.

Another few words: this workaround may be better to be done in https://github.com/Qix-/color-string. But the dependency of `color-string` by `color` is still 0.3.0 and it's quite an old version comparing to latest one. So I chose the easiest way.
