### PR TITLE
add support for opengl/webgl rgba

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,7 +90,7 @@ Color.prototype = {
 		var rgb = this.values.rgb;
 		return rgb.concat([this.values.alpha]);
 	},
-	glRgbaArray: function () {
+	rgbaArrayNormalized: function () {
 		var rgb = this.values.rgb;
 		var glRgba = [];
 		for (var i = 0; i < 3; i++) {

--- a/index.js
+++ b/index.js
@@ -90,6 +90,14 @@ Color.prototype = {
 		var rgb = this.values.rgb;
 		return rgb.concat([this.values.alpha]);
 	},
+	glRgbaArray: function () {
+		var rgb = this.values.rgb,
+			glRgba = [];
+		for (var i = 0; i < 3; i++) {
+			glRgb[i] = rgb[i] / 255;
+		}
+		return glRgba.concat([this.values.alpha]);
+	},
 	hslaArray: function () {
 		var hsl = this.values.hsl;
 		return hsl.concat([this.values.alpha]);

--- a/index.js
+++ b/index.js
@@ -91,12 +91,13 @@ Color.prototype = {
 		return rgb.concat([this.values.alpha]);
 	},
 	glRgbaArray: function () {
-		var rgb = this.values.rgb,
-			glRgba = [];
+		var rgb = this.values.rgb;
+		var glRgba = [];
 		for (var i = 0; i < 3; i++) {
-			glRgb[i] = rgb[i] / 255;
+			glRgba[i] = rgb[i] / 255;
 		}
-		return glRgba.concat([this.values.alpha]);
+		glRgba.push(this.values.alpha);
+		return glRgba;
 	},
 	hslaArray: function () {
 		var hsl = this.values.hsl;

--- a/test/index.js
+++ b/test/index.js
@@ -298,13 +298,13 @@ it('Array getters', function () {
 		r: 10,
 		g: 20,
 		b: 30
-	}).glRgbaArray(), [10 / 255, 20 / 255, 30 / 255, 1]);
+	}).rgbaArrayNormalized(), [10 / 255, 20 / 255, 30 / 255, 1]);
 	deepEqual(Color({
 		r: 10,
 		g: 20,
 		b: 30,
 		a: 0.5
-	}).glRgbaArray(), [10 / 255, 20 / 255, 30 / 255, 0.5]);
+	}).rgbaArrayNormalized(), [10 / 255, 20 / 255, 30 / 255, 0.5]);
 	deepEqual(Color({
 		h: 10,
 		s: 20,

--- a/test/index.js
+++ b/test/index.js
@@ -295,6 +295,17 @@ it('Array getters', function () {
 		b: 30
 	}).rgbArray(), [10, 20, 30]);
 	deepEqual(Color({
+		r: 10,
+		g: 20,
+		b: 30
+	}).glRgbaArray(), [10 / 255, 20 / 255, 30 / 255, 1]);
+	deepEqual(Color({
+		r: 10,
+		g: 20,
+		b: 30,
+		a: 0.5
+	}).glRgbaArray(), [10 / 255, 20 / 255, 30 / 255, 0.5]);
+	deepEqual(Color({
 		h: 10,
 		s: 20,
 		l: 30


### PR DESCRIPTION
add a new method .glRgbaArray() for webgl RGBA colors.

Because RGBA system in webgl is different from CSS whose values are from 0 to 1, this method is convenient to deal with colors in webgl.