### PR TITLE
Version 1.x Makeover (Rewrite + New Features + Bugfixes)

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
   },
   "dependencies": {
     "clone": "^1.0.2",
-    "color-convert": "^1.3.0",
-    "color-string": "^0.3.0"
+    "color-convert": "^1.8.2",
+    "color-string": "^1.3.1"
   },
   "devDependencies": {
     "mocha": "^2.2.5",

--- a/test/index.js
+++ b/test/index.js
@@ -6,76 +6,83 @@ var Color = require('..');
 var deepEqual = assert.deepEqual;
 var equal = assert.equal;
 var ok = assert.ok;
-var strictEqual = assert.strictEqual;
 var notStrictEqual = assert.notStrictEqual;
 var throws = assert.throws;
 
 it('Color() instance', function () {
 	equal(new Color('red').red(), 255);
 	ok((new Color()) instanceof Color);
+	var c = Color();
+	notStrictEqual(c.rgb(), c.rgb());
+});
+
+it('Immutability', function () {
+	var c = Color(0xFF0000);
+	ok(c !== c.rgb());
+	ok(c != c.rgb()); // eslint-disable-line eqeqeq
 });
 
 it('Color() argument', function () {
-	deepEqual(Color('#0A1E19').rgb(), {
+	deepEqual(Color('#0A1E19').rgb().object(), {
 		r: 10,
 		g: 30,
 		b: 25
 	});
-	deepEqual(Color('rgb(10, 30, 25)').rgb(), {
+	deepEqual(Color('rgb(10, 30, 25)').rgb().object(), {
 		r: 10,
 		g: 30,
 		b: 25
 	});
-	deepEqual(Color('rgba(10, 30, 25, 0.4)').rgb(), {
+	deepEqual(Color('rgba(10, 30, 25, 0.4)').rgb().object(), {
 		r: 10,
 		g: 30,
 		b: 25,
-		a: 0.4
+		alpha: 0.4
 	});
-	deepEqual(Color('rgb(4%, 12%, 10%)').rgb(), {
+	deepEqual(Color('rgb(4%, 12%, 10%)').rgb().object(), {
 		r: 10,
 		g: 31,
 		b: 26
 	});
-	deepEqual(Color('rgba(4%, 12%, 10%, 0.4)').rgb(), {
+	deepEqual(Color('rgba(4%, 12%, 10%, 0.4)').rgb().object(), {
 		r: 10,
 		g: 31,
 		b: 26,
-		a: 0.4
+		alpha: 0.4
 	});
-	deepEqual(Color('blue').rgb(), {
+	deepEqual(Color('blue').rgb().object(), {
 		r: 0,
 		g: 0,
 		b: 255
 	});
-	deepEqual(Color('hsl(120, 50%, 60%)').hsl(), {
+	deepEqual(Color('hsl(120, 50%, 60%)').hsl().object(), {
 		h: 120,
 		s: 50,
 		l: 60
 	});
-	deepEqual(Color('hsla(120, 50%, 60%, 0.4)').hsl(), {
+	deepEqual(Color('hsla(120, 50%, 60%, 0.4)').hsl().object(), {
 		h: 120,
 		s: 50,
 		l: 60,
-		a: 0.4
+		alpha: 0.4
 	});
-	deepEqual(Color('hwb(120, 50%, 60%)').hwb(), {
+	deepEqual(Color('hwb(120, 50%, 60%)').hwb().object(), {
 		h: 120,
 		w: 50,
 		b: 60
 	});
-	deepEqual(Color('hwb(120, 50%, 60%, 0.4)').hwb(), {
+	deepEqual(Color('hwb(120, 50%, 60%, 0.4)').hwb().object(), {
 		h: 120,
 		w: 50,
 		b: 60,
-		a: 0.4
+		alpha: 0.4
 	});
 
 	deepEqual(Color({
 		r: 10,
 		g: 30,
 		b: 25
-	}).rgb(), {
+	}).rgb().object(), {
 		r: 10,
 		g: 30,
 		b: 25
@@ -84,7 +91,7 @@ it('Color() argument', function () {
 		h: 10,
 		s: 30,
 		l: 25
-	}).hsl(), {
+	}).hsl().object(), {
 		h: 10,
 		s: 30,
 		l: 25
@@ -93,7 +100,7 @@ it('Color() argument', function () {
 		h: 10,
 		s: 30,
 		v: 25
-	}).hsv(), {
+	}).hsv().object(), {
 		h: 10,
 		s: 30,
 		v: 25
@@ -102,7 +109,7 @@ it('Color() argument', function () {
 		h: 10,
 		w: 30,
 		b: 25
-	}).hwb(), {
+	}).hwb().object(), {
 		h: 10,
 		w: 30,
 		b: 25
@@ -112,55 +119,7 @@ it('Color() argument', function () {
 		m: 30,
 		y: 25,
 		k: 10
-	}).cmyk(), {
-		c: 10,
-		m: 30,
-		y: 25,
-		k: 10
-	});
-
-	deepEqual(Color({
-		red: 10,
-		green: 30,
-		blue: 25
-	}).rgb(), {
-		r: 10,
-		g: 30,
-		b: 25
-	});
-	deepEqual(Color({
-		hue: 10,
-		saturation: 30,
-		lightness: 25
-	}).hsl(), {
-		h: 10,
-		s: 30,
-		l: 25
-	});
-	deepEqual(Color({
-		hue: 10,
-		saturation: 30,
-		value: 25
-	}).hsv(), {
-		h: 10,
-		s: 30,
-		v: 25
-	});
-	deepEqual(Color({
-		hue: 10,
-		whiteness: 30,
-		blackness: 25
-	}).hwb(), {
-		h: 10,
-		w: 30,
-		b: 25
-	});
-	deepEqual(Color({
-		cyan: 10,
-		magenta: 30,
-		yellow: 25,
-		black: 10
-	}).cmyk(), {
+	}).cmyk().object(), {
 		c: 10,
 		m: 30,
 		y: 25,
@@ -169,85 +128,65 @@ it('Color() argument', function () {
 });
 
 it('Setters', function () {
-	deepEqual(Color().rgb(10, 30, 25).rgb(), {
+	deepEqual(Color.rgb(10, 30, 25).rgb().object(), {
 		r: 10,
 		g: 30,
 		b: 25
 	});
-	deepEqual(Color().rgb(10, 30, 25, 0.4).rgb(), {
+	deepEqual(Color.rgb(10, 30, 25, 0.4).rgb().object(), {
 		r: 10,
 		g: 30,
 		b: 25,
-		a: 0.4
-	});
-	deepEqual(Color().rgb([10, 30, 25]).rgb(), {
-		r: 10,
-		g: 30,
-		b: 25
-	});
-	deepEqual(Color().rgb([10, 30, 25, 0.4]).rgb(), {
-		r: 10,
-		g: 30,
-		b: 25,
-		a: 0.4
-	});
-	deepEqual(Color().rgb({
-		r: 10,
-		g: 30,
-		b: 25
-	}).rgb(), {
-		r: 10,
-		g: 30,
-		b: 25
-	});
-	deepEqual(Color().rgb({
-		r: 10,
-		g: 30,
-		b: 25,
-		a: 0.4
-	}).rgb(), {
-		r: 10,
-		g: 30,
-		b: 25,
-		a: 0.4
-	});
-	deepEqual(Color().rgb({
-		red: 10,
-		green: 30,
-		blue: 25
-	}).rgb(), {
-		r: 10,
-		g: 30,
-		b: 25
-	});
-	deepEqual(Color().rgb({
-		red: 10,
-		green: 30,
-		blue: 25,
 		alpha: 0.4
-	}).rgb(), {
+	});
+	deepEqual(Color.rgb([10, 30, 25]).rgb().object(), {
+		r: 10,
+		g: 30,
+		b: 25
+	});
+	deepEqual(Color.rgb([10, 30, 25, 0.4]).rgb().object(), {
 		r: 10,
 		g: 30,
 		b: 25,
-		a: 0.4
+		alpha: 0.4
+	});
+	deepEqual(Color.rgb({
+		r: 10,
+		g: 30,
+		b: 25
+	}).rgb().object(), {
+		r: 10,
+		g: 30,
+		b: 25
+	});
+	deepEqual(Color.rgb({
+		r: 10,
+		g: 30,
+		b: 25,
+		alpha: 0.4
+	}).rgb().object(), {
+		r: 10,
+		g: 30,
+		b: 25,
+		alpha: 0.4
 	});
 
-	deepEqual(Color().hsl([260, 10, 10]).hsl(), {
+	deepEqual(Color.hsl([260, 10, 10]).hsl().object(), {
 		h: 260,
 		s: 10,
 		l: 10
 	});
-	deepEqual(Color().hsv([260, 10, 10]).hsv(), {
+	deepEqual(Color.hsv([260, 10, 10]).hsv().object(), {
 		h: 260,
 		s: 10,
 		v: 10
 	});
-	deepEqual(Color().hwb([260, 10, 10]).hwb(), {
+	deepEqual(Color.hwb([260, 10, 10]).hwb().object(), {
 		h: 260,
 		w: 10,
 		b: 10
 	});
-	deepEqual(Color().cmyk([10, 10, 10, 10]).cmyk(), {
+	deepEqual(Color.cmyk([10, 10, 10, 10]).cmyk().object(), {
 		c: 10,
 		m: 10,
 		y: 10,
@@ -255,32 +194,32 @@ it('Setters', function () {
 	});
 });
 
-it('retain alpha', function () {
-	equal(Color().rgb([10, 30, 25, 0.4]).rgb([10, 30, 25]).alpha(), 0.4);
+it('Retain Alpha', function () {
+	equal(Color.rgb(1, 2, 3, 0.4).ansi256().rgb().alpha(), 0.4);
 });
 
 it('Translations', function () {
-	deepEqual(Color().rgb(10, 30, 25).rgb(), {
+	deepEqual(Color.rgb(10, 30, 25).rgb().round().object(), {
 		r: 10,
 		g: 30,
 		b: 25
 	});
-	deepEqual(Color().rgb(10, 30, 25).hsl(), {
+	deepEqual(Color.rgb(10, 30, 25).hsl().round().object(), {
 		h: 165,
 		s: 50,
 		l: 8
 	});
-	deepEqual(Color().rgb(10, 30, 25).hsv(), {
+	deepEqual(Color.rgb(10, 30, 25).hsv().round().object(), {
 		h: 165,
 		s: 67,
 		v: 12
 	});
-	deepEqual(Color().rgb(10, 30, 25).hwb(), {
+	deepEqual(Color.rgb(10, 30, 25).hwb().round().object(), {
 		h: 165,
 		w: 4,
 		b: 88
 	});
-	deepEqual(Color().rgb(10, 30, 25).cmyk(), {
+	deepEqual(Color.rgb(10, 30, 25).cmyk().round().object(), {
 		c: 67,
 		m: 0,
 		y: 17,
@@ -293,39 +232,39 @@ it('Array getters', function () {
 		r: 10,
 		g: 20,
 		b: 30
-	}).rgbArray(), [10, 20, 30]);
+	}).rgb().array(), [10, 20, 30]);
 	deepEqual(Color({
 		r: 10,
 		g: 20,
 		b: 30
-	}).rgbaArrayNormalized(), [10 / 255, 20 / 255, 30 / 255, 1]);
+	}).unitArray(), [10 / 255, 20 / 255, 30 / 255]);
 	deepEqual(Color({
 		r: 10,
 		g: 20,
 		b: 30,
-		a: 0.5
-	}).rgbaArrayNormalized(), [10 / 255, 20 / 255, 30 / 255, 0.5]);
+		alpha: 0.5
+	}).unitArray(), [10 / 255, 20 / 255, 30 / 255, 0.5]);
 	deepEqual(Color({
 		h: 10,
 		s: 20,
 		l: 30
-	}).hslArray(), [10, 20, 30]);
+	}).hsl().array(), [10, 20, 30]);
 	deepEqual(Color({
 		h: 10,
 		s: 20,
 		v: 30
-	}).hsvArray(), [10, 20, 30]);
+	}).hsv().array(), [10, 20, 30]);
 	deepEqual(Color({
 		h: 10,
 		w: 20,
 		b: 30
-	}).hwbArray(), [10, 20, 30]);
+	}).hwb().array(), [10, 20, 30]);
 	deepEqual(Color({
 		c: 10,
 		m: 20,
 		y: 30,
 		k: 40
-	}).cmykArray(), [10, 20, 30, 40]);
+	}).cmyk().array(), [10, 20, 30, 40]);
 });
 
 it('Multiple times', function () {
@@ -334,8 +273,8 @@ it('Multiple times', function () {
 		g: 20,
 		b: 30
 	});
-	deepEqual(color.rgbaArray(), [10, 20, 30, 1]);
-	deepEqual(color.rgbaArray(), [10, 20, 30, 1]);
+	deepEqual(color.rgb().array(), [10, 20, 30]);
+	deepEqual(color.rgb().array(), [10, 20, 30]);
 });
 
 it('Channel getters/setters', function () {
@@ -343,13 +282,13 @@ it('Channel getters/setters', function () {
 		r: 10,
 		g: 20,
 		b: 30,
-		a: 0.4
+		alpha: 0.4
 	}).alpha(), 0.4);
 	equal(Color({
 		r: 10,
 		g: 20,
 		b: 30,
-		a: 0.4
+		alpha: 0.4
 	}).alpha(0.7).alpha(), 0.7);
 	equal(Color({
 		r: 10,
@@ -431,73 +370,73 @@ it('Setting the same value', function () {
 	var green = color.green();
 	var blue = color.blue();
 	var hue = color.hue();
-	var saturation = color.saturation();
+	var saturation = color.saturationl();
 	var saturationv = color.saturationv();
 	var lightness = color.lightness();
-	var whiteness = color.whiteness();
-	var blackness = color.blackness();
+	var whiteness = color.white();
+	var blackness = color.wblack();
 	var cyan = color.cyan();
 	var magenta = color.magenta();
 	var yellow = color.yellow();
 	var black = color.black();
 
-	equal(color.hexString(), colorString);
+	equal(color.hex(), colorString);
 
 	color.alpha(alpha);
 	equal(color.alpha(), alpha);
-	equal(color.hexString(), colorString);
+	equal(color.hex(), colorString);
 
 	color.red(red);
 	equal(color.red(), red);
-	equal(color.hexString(), colorString);
+	equal(color.hex(), colorString);
 
 	color.green(green);
 	equal(color.green(), green);
-	equal(color.hexString(), colorString);
+	equal(color.hex(), colorString);
 
 	color.blue(blue);
 	equal(color.blue(), blue);
-	equal(color.hexString(), colorString);
+	equal(color.hex(), colorString);
 
 	color.hue(hue);
 	equal(color.hue(), hue);
-	equal(color.hexString(), colorString);
+	equal(color.hex(), colorString);
 
-	color.saturation(saturation);
-	equal(color.saturation(), saturation);
-	equal(color.hexString(), colorString);
+	color.saturationl(saturation);
+	equal(color.saturationl(), saturation);
+	equal(color.hex(), colorString);
 
 	color.saturationv(saturationv);
 	equal(color.saturationv(), saturationv);
-	equal(color.hexString(), colorString);
+	equal(color.hex(), colorString);
 
 	color.lightness(lightness);
 	equal(color.lightness(), lightness);
-	equal(color.hexString(), colorString);
+	equal(color.hex(), colorString);
 
-	color.whiteness(whiteness);
-	equal(color.whiteness(), whiteness);
-	equal(color.hexString(), colorString);
+	color.white(whiteness);
+	equal(color.white(), whiteness);
+	equal(color.hex(), colorString);
 
-	color.blackness(blackness);
-	equal(color.blackness(), blackness);
-	equal(color.hexString(), colorString);
+	color.wblack(blackness);
+	equal(color.wblack(), blackness);
+	equal(color.hex(), colorString);
 
 	color.cyan(cyan);
 	equal(color.cyan(), cyan);
-	equal(color.hexString(), colorString);
+	equal(color.hex(), colorString);
 
 	color.magenta(magenta);
 	equal(color.magenta(), magenta);
-	equal(color.hexString(), colorString);
+	equal(color.hex(), colorString);
 
 	color.yellow(yellow);
 	equal(color.yellow(), yellow);
-	equal(color.hexString(), colorString);
+	equal(color.hex(), colorString);
 
 	color.black(black);
 	equal(color.black(), black);
-	equal(color.hexString(), colorString);
+	equal(color.hex(), colorString);
 });
 
 it('Capping values', function () {
@@ -505,7 +444,7 @@ it('Capping values', function () {
 		h: 400,
 		s: 50,
 		l: 10
-	}).hue(), 360);
+	}).hue(), 40);
 	equal(Color({
 		h: 100,
 		s: 50,
@@ -515,29 +454,29 @@ it('Capping values', function () {
 		h: -400,
 		s: 50,
 		l: 10
-	}).hue(), 0);
+	}).hue(), 320);
 
 	// 0 == 360
 	equal(Color({
 		h: 400,
 		w: 50,
 		b: 10
-	}).hue(), 0);
+	}).hue(), 40);
 	equal(Color({
 		h: 100,
 		w: 50,
 		b: 80
-	}).blacken(0.5).blackness(), 100);
+	}).blacken(0.5).wblack(), 100);
 	equal(Color({
 		h: -400,
 		w: 50,
 		b: 10
-	}).hue(), 0);
+	}).hue(), 320);
 
 	equal(Color().red(400).red(), 255);
 	equal(Color().red(-400).red(), 0);
-	equal(Color().rgb(10, 10, 10, 12).alpha(), 1);
-	equal(Color().rgb(10, 10, 10, -200).alpha(), 0);
+	equal(Color.rgb(10, 10, 10, 12).alpha(), 1);
+	equal(Color.rgb(10, 10, 10, -200).alpha(), 0);
 	equal(Color().alpha(-12).alpha(), 0);
 	equal(Color().alpha(3).alpha(), 1);
 });
@@ -547,7 +486,7 @@ it('Translate with channel setters', function () {
 		r: 0,
 		g: 0,
 		b: 0
-	}).lightness(50).hsl(), {
+	}).lightness(50).hsl().object(), {
 		h: 0,
 		s: 0,
 		l: 50
@@ -556,7 +495,7 @@ it('Translate with channel setters', function () {
 		r: 0,
 		g: 0,
 		b: 0
-	}).red(50).green(50).hsv(), {
+	}).red(50).green(50).hsv().round().object(), {
 		h: 60,
 		s: 100,
 		v: 20
@@ -564,22 +503,21 @@ it('Translate with channel setters', function () {
 });
 
 it('CSS String getters', function () {
-	equal(Color('rgb(10, 30, 25)').hexString(), '#0A1E19');
-	equal(Color('rgb(10, 30, 25)').rgbString(), 'rgb(10, 30, 25)');
-	equal(Color('rgb(10, 30, 25, 0.4)').rgbString(), 'rgba(10, 30, 25, 0.4)');
+	equal(Color('rgb(10, 30, 25)').hex(), '#0A1E19');
+	equal(Color('rgb(10, 30, 25)').rgb().string(), 'rgb(10, 30, 25)');
+	equal(Color('rgb(10, 30, 25, 0.4)').rgb().string(), 'rgba(10, 30, 25, 0.4)');
 	equal(Color('rgb(10, 30, 25)').percentString(), 'rgb(4%, 12%, 10%)');
 	equal(Color('rgb(10, 30, 25, 0.3)').percentString(), 'rgba(4%, 12%, 10%, 0.3)');
-	equal(Color('rgb(10, 30, 25)').hslString(), 'hsl(165, 50%, 8%)');
-	equal(Color('rgb(10, 30, 25, 0.3)').hslString(), 'hsla(165, 50%, 8%, 0.3)');
+	equal(Color('rgb(10, 30, 25)').hsl().string(), 'hsl(165, 50%, 7.8%)');
+	equal(Color('rgb(10, 30, 25, 0.3)').hsl().string(), 'hsla(165, 50%, 7.8%, 0.3)');
 	equal(Color({
 		h: 0,
 		s: 0,
 		v: 100
-	}).hslString(), 'hsl(0, 0%, 100%)');
-	equal(Color('rgb(10, 30, 25)').hwbString(), 'hwb(165, 4%, 88%)');
-	equal(Color('rgb(10, 30, 25, 0.3)').hwbString(), 'hwb(165, 4%, 88%, 0.3)');
+	}).hsl().string(), 'hsl(0, 0%, 100%)');
+	equal(Color('rgb(10, 30, 25)').hwb().string(0), 'hwb(165, 4%, 88%)');
+	equal(Color('rgb(10, 30, 25, 0.3)').hwb().string(0), 'hwb(165, 4%, 88%, 0.3)');
 	equal(Color('rgb(0, 0, 255)').keyword(), 'blue');
-	strictEqual(Color('rgb(10, 30, 25)').keyword(), undefined);
 });
 
 it('Number getters', function () {
@@ -610,7 +548,7 @@ it('Manipulators wo/ mix', function () {
 		r: 67,
 		g: 122,
 		b: 134
-	}).greyscale().rgb(), {
+	}).grayscale().rgb().round().object(), {
 		r: 107,
 		g: 107,
 		b: 107
@@ -619,7 +557,7 @@ it('Manipulators wo/ mix', function () {
 		r: 67,
 		g: 122,
 		b: 134
-	}).negate().rgb(), {
+	}).negate().rgb().round().object(), {
 		r: 188,
 		g: 133,
 		b: 121
@@ -638,33 +576,33 @@ it('Manipulators wo/ mix', function () {
 		h: 100,
 		w: 50,
 		b: 60
-	}).whiten(0.5).whiteness(), 75);
+	}).whiten(0.5).white(), 75);
 	equal(Color({
 		h: 100,
 		w: 50,
 		b: 60
-	}).blacken(0.5).blackness(), 90);
+	}).blacken(0.5).wblack(), 90);
 	equal(Color({
 		h: 100,
 		s: 40,
 		l: 50
-	}).saturate(0.5).saturation(), 60);
+	}).saturate(0.5).saturationl(), 60);
 	equal(Color({
 		h: 100,
 		s: 80,
 		l: 60
-	}).desaturate(0.5).saturation(), 40);
+	}).desaturate(0.5).saturationl(), 40);
 	equal(Color({
 		r: 10,
 		g: 10,
 		b: 10,
-		a: 0.8
-	}).clearer(0.5).alpha(), 0.4);
+		alpha: 0.8
+	}).fade(0.5).alpha(), 0.4);
 	equal(Color({
 		r: 10,
 		g: 10,
 		b: 10,
-		a: 0.5
+		alpha: 0.5
 	}).opaquer(0.5).alpha(), 0.75);
 	equal(Color({
 		h: 60,
@@ -679,59 +617,27 @@ it('Manipulators wo/ mix', function () {
 });
 
 it('Mix: basic', function () {
-	equal(Color('#f00').mix(Color('#00f')).hexString(), '#800080');
+	equal(Color('#f00').mix(Color('#00f')).hex(), '#800080');
 });
 
 it('Mix: weight', function () {
-	equal(Color('#f00').mix(Color('#00f'), 0.25).hexString(), '#4000BF');
+	equal(Color('#f00').mix(Color('#00f'), 0.25).hex(), '#4000BF');
 });
 
 it('Mix: alpha', function () {
-	equal(Color('rgba(255, 0, 0, 0.5)').mix(Color('#00f')).rgbaString(), 'rgba(64, 0, 191, 0.75)');
+	equal(Color('rgba(255, 0, 0, 0.5)').mix(Color('#00f')).rgb().string(0), 'rgba(64, 0, 191, 0.75)');
 });
 
 it('Mix: 50%', function () {
-	equal(Color('#f00').mix(Color('#00f'), 0.5).hexString(), '#800080');
+	equal(Color('#f00').mix(Color('#00f'), 0.5).hex(), '#800080');
 });
 
 it('Mix: 0%', function () {
-	equal(Color('#f00').mix(Color('#00f'), 0).hexString(), '#0000FF');
+	equal(Color('#f00').mix(Color('#00f'), 0).hex(), '#0000FF');
 });
 
 it('Mix: 100%', function () {
-	equal(Color('#f00').mix(Color('#00f'), 1.0).hexString(), '#FF0000');
-});
-
-it('Clone', function () {
-	var clone = Color({
-		r: 10,
-		g: 20,
-		b: 30
-	});
-	notStrictEqual(clone, clone.clone());
-	deepEqual(clone.rgbaArray(), [10, 20, 30, 1]);
-	deepEqual(clone.clone().rgbaArray(), [10, 20, 30, 1]);
-	deepEqual(clone.clone().rgb(50, 40, 30).rgbaArray(), [50, 40, 30, 1]);
-	deepEqual(clone.rgbaArray(), [10, 20, 30, 1]);
-});
-
-it('Clone: default constructor', function () {
-	var defaultColor = Color();
-	var clonedFromDefault = defaultColor.clone();
-
-	// same tests used in base case 'Clone'
-	notStrictEqual(defaultColor, clonedFromDefault);
-	deepEqual(defaultColor.rgbaArray(), [0, 0, 0, 1]);
-	deepEqual(defaultColor.clone().rgbaArray(), [0, 0, 0, 1]);
-	deepEqual(defaultColor.clone().rgb(0, 0, 0).rgbaArray(), [0, 0, 0, 1]);
-	deepEqual(defaultColor.rgbaArray(), [0, 0, 0, 1]);
-
-	// additional checks
-	deepEqual(clonedFromDefault.rgbaArray(), [0, 0, 0, 1]);
-	equal(
-		defaultColor.hwbString(),
-		clonedFromDefault.hwbString()
-	);
+	equal(Color('#f00').mix(Color('#00f'), 1.0).hex(), '#FF0000');
 });
 
 it('Level', function () {


### PR DESCRIPTION
![MAKEOVER WITH RAINBOWS AND COLORS AND SHIT](https://media.giphy.com/media/3o7TKDMPKsakcn9NU4/source.gif)

> Documentation will be updated after API is finalized. Please be mindful of this!

Here it is, the final piece of the color makeover trilogy. If you recall, I did a makeover of both [`color-string`](https://github.com/Qix-/color-string/pull/22) and [`color-convert`](https://github.com/Qix-/color-convert/pull/27) that have been generally well-received. This was the final piece.

After an increasing number of people expressing some stress over the 'quirkiness' of the API recently, I decided to finally get to it. It's been about an 8 or 9 hour ordeal, which is why I was really good at procrastinating :dancing_men:.

I do already have some things in mind for a 2.x makeover, but that's far into the future and is contingent on the evolution of `color-convert` specifically.

Without further adieu, here are all of the changes. Keep in mind this is a _complete_ re-write with a pretty good portion of the API being compatible with the 0.x releases.

### The Fun Parts (new stuff, fixes, etc.)
- (Closes #56) Completely immutable API.
- (Fixes #42) All color models from [`color-convert`](https://github.com/qix-/color-convert) are supported (using `.<model-name>()`). Try it yourself!

```javascript
Color(0xFF0000).rgb().hsl().lab().hwb().xyz().cmyk().ansi256().rgb().toString()
```

Yes, this does mean that portion of the API has changed. Please see the migrations section below.

- Main `Color` class now has swizzle-able model constructors (e.g. `Color.cmyk(10, 20, 30, 40)`, `Color.rgb([15, 67, 200])`, etc.).
- No longer performs conversion for every model on every single operation - smaller footprint and faster computation times. Not entirely sure why we were doing this to begin with, but whatever.
- (Fixes #79) Constructor now supports non-string hexadecimal RGB instantiation
- (Fixes #87) `.toString()` now returns a color string.
- Added [HCG](https://github.com/Qix-/color-convert/pull/29)-specific getters/setters.
- (Fixes #42) Added XYZ/Lab getters/setters.
- (Fixes #83, #57, #93) Added a `.round()` function that takes a number of places (default is 0) to round the internal values to. The modified `.string()` and `.percentString()` methods also take this parameter, and those methods default to 1. See notes below.
- (Fixes #82) Several API clarifications. See Migrations section below.

As well, bumping the dependencies fixes #74.

### The Not-So-Fun Parts (migration)
- **Everything is immutable**. There isn't a single fix for this if you (ab)used this library earlier on - you'll most likely be tweaking several touch points. It's for the greater good, I promise. If you already treated the library as immutable then you're probably good to go. Good tests are key here.
- All `.model()` functions (to convert to an object) must now be `.model().object()`. See notes below for justification.
- All `.modelArray()` functions must now be `.model().array()`. See notes below for justification.
- When using the `.object()` method, alpha values are now `.alpha` instead of `.a` so as to not conflict with Lab.
- If you used the internal properties of the object instead of getters, you'll need to.. not do that anymore :) Use the respective model calls (`.rgb()`, `.hsl()`, etc.) paired with `.array()` - this is because we don't store *every single* model in the object at once, but simply the last worked-with model.
- `.whiteness()` / `.blackness()` -> `.white()` / `.wblack()` (note the `w` prefix).

I want to explain this one because it doesn't feel _'great'_ but I felt like it needed to happen. We have had a couple of issues (#73 being the most definitive) that address problems with the assumed functionality of the methods.

I chose to remove the `-ness` from the names because I didn't want them being interpreted as a _characteristic_ of the color, but instead a more concrete, _'absolute'_ (if you will) property of a specific color model (akin to `.cyan()`, `.red()`, `.hue()`, etc.).

The `w` prefix was chosen for both objective and subjective reasons: it objectively conflicts with CMYK's `.black()`, and HWB subjectively isn't used as much as CMYK is (please let me know if this is an abhorrently wrong assumption). Further, we have another example of the API doing this that nobody has complained about since I took over - `.saturationl()` and `.saturationv()` for the HSV and HSL models.

Also, since this seems like a good place to mention it - in lieu of something like `.lightnessab()` for the Lab model, I just stuck with `.l()`. In the future, I hope to have something a little more consistent, but for now this works.
- Constructors with specialized keys (such as `.red`, `.green` and `.blue` for RGB instead of `.r`, `.g.` and `.b`) were removed. If this is a huge problem, please let me know. For clarity, this means you can no longer instantiate with `Color({red: 10, green: 100, blue: 150})` but instead must use `Color({r: 10, g: 100, b: 150})`.
- The model getter methods (e.g. `.rgb()`, `.hsl()`, `.keyword()`) no longer act as setters. Since everything is immutable now, such functionality is useless and only creates more overhead. Please use the `Color()` constructor directly, or use the new 'static' methods (functions) such as `Color.rgb()` directly.
- (Closes #67, #46) `.clone()` was removed since all objects are immutable. Just pass objects directly. If you _really_ need a new copy of an object, use `Color(otherColorObject)`.
- `rgbaString()` was removed. If you really need a string that forces the alpha value, please let me know and I can add something into the API. Otherwise, use `.rgbString()` and if the alpha is anything but 100% then it will include it.
- The specialized `.xxxString()` methods should move to `.xxx().string()` calls. In the case you need the RGB percent string, you may still use `.percentString()` - it will automatically convert to the RGB model. For instance, if you used `.hslString()`, you would now call `.hsl().string()`.
- `.clearer()` -> `.fade()`, because "clearer" is not at all what I thought it was personally and the API is already kind of confusing (I thought clearer meant more saturated).
- `.toJSON()` now returns the current model's representation. If you absolutely need RGB, tack on `.rgb()`. This shouldn't affect many people, if any.
- Values no longer normalize (round) when getting objects or arrays. Call `.round()` first. **If you are seeing crazy long decimals, this is why.** I wanted to be sensitive to the scientific community that is using this library to perform more mathematically sensitive operations instead of approximate stuff for web users. Most people won't have a problem with this since most people use the CSS strings.
- (Fixes #24) Initializing a `Color` object with a hue-based model (hsl, hwb, etc.) performs a rotation on the value instead of clamping it to 0-360. This is in-line with the `.hue()` getter/setter and I believe it to be the correct functionality to begin with.
- `.greyscale()` -> `.grayscale()` - if you think we should have both, please let me know :)
- (Closes #86) `.saturation()` -> `.saturationl()` (to match `.saturationv()`)

### Some Notes

So why the extra three characters for things like `.hslString()` -> `.hsl().string()`? Two reasons - one, you can now snap colors to another model if necessary. For example, if I wanted to snap a color to the nearest ANSI 256 color, I can do `Color(123, 44, 220).ansi256().rgb().object()`; two, the dependencies (e.g. [`color-string`](https://github.com/qix-/color-string)) have pretty good parity with the model names used in `color-convert`, and `color-convert` has evolved a bit since the 0.x releases of `color` to a point where we can intelligently include most models, and can future-proof new models just by updating `color-convert` in `color`'s package.json.

Further, a lot of these changes are due to the internal object no longer holding _every single conversion possible_. `color-convert` now supports [quite a lot of conversion routes](https://github.com/Qix-/color-convert#routing) and maintaining all of them here was impractical, messy and tedious.

As mentioned earlier, another win is that you're going to save quite a bit of processing time, so applications that are doing things like color manipulation on images and whatnot should benefit greatly by switching to 1.x.

### Next Steps

After this PR is approved by the community and merged, it will be published as 1.0.0.

After that, there will be a few efforts moving forward:

- Tests (of course) - I noticed comprehensive tests are lacking, and a test makeover would be beneficial in its own right.
- More transformations, and more _clarity_ as to what those transformations are.
- Color scheme support (#44)
- Color space support (maybe)

I think the first thing that should be tackled now that we will have a slightly cleaner code base is to figure out some of the hairy naming that is going on here. I would love to hear some ideas about this (feel free to drop as many tickets as you'd like) - I have some of my own, but I don't always have the best ideas!

### Feedback!

I need feedback on this as I am not a primary user of this library (admittedly I use `color-convert` more than `color` proper) so I want to make sure the *users* of this library are satisfied before I merge it in. There are a _lot_ of opinionated changes in here that I have included based on all of the tickets and pull requests I've received.

Another thing I'd like to point out - this library is edge-case hell. Making decisions that benefitted all users, use cases, and color models, elegantly and without a ton of overhead, was incredibly difficult. I've attempted this rewrite probably 4 or 5 times now, ultimately scrapping it and trying again a month or two later.

If you have any strong feelings, or even not-so-strong feelings, please let me know. I'd love to know what could be done better.

Obligatory CC list:
// @MoOx @sindresorhus @kevinsuttle @mattbasta @xml @huan086 @ooflorent @mindjuice @wmira @lapanoid @ZuBB @iamstarkov @stevemao @ericclemmons @igl @dliv 

Thanks everybody!