### PR TITLE
Lighten and Darken functionality not working as expected

### DIFF
--- a/index.js
+++ b/index.js
@@ -305,13 +305,13 @@ Color.prototype = {
 
 	lighten: function (ratio) {
 		var hsl = this.hsl();
-		hsl.color[2] = hsl.color[2] + ((100 - hsl.color[2]) * ratio)
+		hsl.color[2] = hsl.color[2] + ((100 - hsl.color[2]) * ratio);
 		return hsl;
 	},
 
 	darken: function (ratio) {
 		var hsl = this.hsl();
-		hsl.color[2] = hsl.color[2] - (hsl.color[2] * ratio)
+		hsl.color[2] = hsl.color[2] - (hsl.color[2] * ratio);
 		return hsl;
 	},
 

--- a/index.js
+++ b/index.js
@@ -305,13 +305,13 @@ Color.prototype = {
 
 	lighten: function (ratio) {
 		var hsl = this.hsl();
-		hsl.color[2] += hsl.color[2] * ratio;
+		hsl.color[2] = hsl.color[2] + ((100 - hsl.color[2]) * ratio)
 		return hsl;
 	},
 
 	darken: function (ratio) {
 		var hsl = this.hsl();
-		hsl.color[2] -= hsl.color[2] * ratio;
+		hsl.color[2] = hsl.color[2] - (hsl.color[2] * ratio)
 		return hsl;
 	},
 

--- a/index.js
+++ b/index.js
@@ -305,13 +305,13 @@ Color.prototype = {
 
 	lighten: function (ratio) {
 		var hsl = this.hsl();
-		hsl.color[2] = hsl.color[2] + ((100 - hsl.color[2]) * ratio);
+		hsl.color[2] += ((100 - hsl.color[2]) * ratio);
 		return hsl;
 	},
 
 	darken: function (ratio) {
 		var hsl = this.hsl();
-		hsl.color[2] = hsl.color[2] - (hsl.color[2] * ratio);
+		hsl.color[2] -= (hsl.color[2] * ratio);
 		return hsl;
 	},
 

--- a/test/index.js
+++ b/test/index.js
@@ -449,7 +449,7 @@ it('Capping values', function () {
 		h: 100,
 		s: 50,
 		l: 80
-	}).lighten(0.5).lightness(), 100);
+	}).lighten(0.5).lightness(), 90);
 	equal(Color({
 		h: -400,
 		s: 50,
@@ -567,7 +567,7 @@ it('Manipulators wo/ mix', function () {
 		h: 100,
 		s: 50,
 		l: 60
-	}).lighten(0.5).lightness(), 90);
+	}).lighten(0.5).lightness(), 80);
 	equal(Color({
 		h: 100,
 		s: 50,


### PR DESCRIPTION
As evident from the code the lighten and darken functionality of the project uses hsl value and increases or decreases the l value which result in a lighter or darker shade of the color.

The issue that I was facing was that if we have a color with l value approximately 80 and now if we go by the present code ie.
hsl.color[2] += hsl.color[2] * ratio

this actually exceeds the l value over 100 if the ratio is say even 0.25 due to which the color results in white, whereas I felt that the ratio should be increased on the remaining l value (100- hsl.color[2]) . This would give us a lighter shade and if we give ratio as 1 then we can get white color or else we can get a lighter shade of the color.

Likewise the vice versa is applicable for darken it should be decreasing the l value on the present l value that it has.

hsl.color[2] = hsl.color[2] - (hsl.color[2] * ratio)
