### PR TITLE
Alter the mix function to make the weight behave the way the code looks

### DIFF
--- a/index.js
+++ b/index.js
@@ -366,8 +366,8 @@ Color.prototype = {
 	mix: function (mixinColor, weight) {
 		// ported from sass implementation in C
 		// https://github.com/sass/libsass/blob/0e6b4a2850092356aa3ece07c6b249f0221caced/functions.cpp#L209
-		var color1 = this.rgb();
-		var color2 = mixinColor.rgb();
+		var color1 = mixinColor.rgb();
+		var color2 = this.rgb();
 		var p = weight === undefined ? 0.5 : weight;
 
 		var w = 2 * p - 1;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "color",
-  "version": "1.0.3",
+  "version": "2.0.0",
   "description": "Color conversion and manipulation with CSS string support",
   "keywords": [
     "color",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "color",
-  "version": "2.0.0",
+  "version": "1.0.3",
   "description": "Color conversion and manipulation with CSS string support",
   "keywords": [
     "color",

--- a/test/index.js
+++ b/test/index.js
@@ -622,23 +622,31 @@ it('Mix: basic', function () {
 });
 
 it('Mix: weight', function () {
-	equal(Color('#f00').mix(Color('#00f'), 0.25).hex(), '#4000BF');
+	equal(Color('#f00').mix(Color('#00f'), 0.25).hex(), '#BF0040');
 });
 
 it('Mix: alpha', function () {
 	equal(Color('rgba(255, 0, 0, 0.5)').mix(Color('#00f')).rgb().string(0), 'rgba(64, 0, 191, 0.75)');
 });
 
+it('Mix: 0%', function () {
+	equal(Color('#f00').mix(Color('#00f'), 0).hex(), '#FF0000');
+});
+
+it('Mix: 25%', function () {
+	equal(Color('#f00').mix(Color('#00f'), 0.25).hex(), '#BF0040');
+});
+
 it('Mix: 50%', function () {
 	equal(Color('#f00').mix(Color('#00f'), 0.5).hex(), '#800080');
 });
 
-it('Mix: 0%', function () {
-	equal(Color('#f00').mix(Color('#00f'), 0).hex(), '#0000FF');
+it('Mix: 75%', function () {
+	equal(Color('#f00').mix(Color('#00f'), 0.75).hex(), '#4000BF');
 });
 
 it('Mix: 100%', function () {
-	equal(Color('#f00').mix(Color('#00f'), 1.0).hex(), '#FF0000');
+	equal(Color('#f00').mix(Color('#00f'), 1.0).hex(), '#0000FF');
 });
 
 it('Level', function () {


### PR DESCRIPTION
Hi. This came up when I tried to do this:
```
const color = Color(baseColor)
  .mix(Color(hoverColor), values.hover)
  .mix(Color(activeColor), values.active)
  .mix(Color(errorColor), values.error);
```
values is an object that contains 0 to 1 values for the hover, active, and error state which are animated. My thought was that if you start with the baseColor and "mix" the others in with 0 weight I would be left with the base color. Then as the weights animated to 1 I would end up with the full state color.

Turns out that's not what happens, a weight of 0 overwrites the original color while 1 will keep it and use none of the passed in color. I've looked at the [code](https://github.com/sass/libsass/blob/0e6b4a2850092356aa3ece07c6b249f0221caced/functions.cpp#L209) and [documentation](http://sass-lang.com/documentation/Sass/Script/Functions.html#mix-instance_method) [you cited](https://github.com/tsdorsey/color/blob/master/index.js#L368) as the source of the function and it makes sense now.

In the original code it's a function, not a method on an object. So when you write `mix(black, white, 0.1);`. You read that as "mix black into white by 10%". Contrast that with this module where the mix function is a method on a color object. When you write `white.mix(black, 0.1)` it is more natural to read it as "starting with white, mix in black by 10%".

You could argue that it's just me being biased towards reading the `.mix` method as "mix in" when I should have read it as "mix into". My counter to that would be that all of the other alteration methods (`.whiten`, `.blacken`, `.fade`, etc) return the original value when you pass `0` as the amount you want to alter them by. `.mix` on the other hand will return same things only when `1` is passed in. Also of note is that one of the examples in the [README](https://github.com/Qix-/color/blob/master/README.md#propers) file is this: `color.mix(Color("yellow"), 0.3)   // cyan -> rgb(77, 255, 179)` which is the result you get from my alterations but is not the value you'll get with the current mix function. 

In conclusion, I know that could simply write my code as 
```
const color = Color(errorColor)
  .mix(Color(activeColor), values.error)
  .mix(Color(hoverColor), values.active)
  .mix(Color(baseColor), values.hover);
```
but that is WAY more difficult to parse than the example I gave at the start.

In this change I...
- Switched the colors in mix method
- Updated the mix tests
- Added tests for 25% and 75% mixes
- Bumped the version to 2.0.0 (breaking change)