### PR TITLE
Add explicit note on string constructors

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ var color = Color.rgb([255, 255, 255])
 
 Set the values for individual channels with `alpha`, `red`, `green`, `blue`, `hue`, `saturation` (hsl), `saturationv` (hsv), `lightness`, `whiteness`, `blackness`, `cyan`, `magenta`, `yellow`, `black`
 
+String constructors are handled by [color-string](https://www.npmjs.com/package/color-string)
+
 ### Getters
 ```js
 color.hsl();


### PR DESCRIPTION
Added a note on supported string constructors, as it's unclear from docs which string constructors are supported.