### PR TITLE
Change Color.prototype.toJson return type to string

### DIFF
--- a/index.js
+++ b/index.js
@@ -122,7 +122,8 @@ Color.prototype = {
 	},
 
 	toJSON: function () {
-		return this[this.model]();
+		var color = Object.assign({}, this[this.model]());
+		return JSON.stringify(color);
 	},
 
 	string: function (places) {


### PR DESCRIPTION
I have a problem with jest snapshot testing, which expect that objects that have `toJSON` properties return `string` by calling it. But as I understand, in your codebase `toJSON` return object. And this is leads to `Maximum call stack` error in jest. Is there any reasons for this?


Jest [source](https://github.com/facebook/jest/blob/master/packages/pretty-format/src/index.js#L194) that use `toJSON`