### PR TITLE
Corrected contrast ratio for enhanced contrast

### DIFF
--- a/index.js
+++ b/index.js
@@ -277,7 +277,7 @@ Color.prototype = {
 
 	level: function (color2) {
 		var contrastRatio = this.contrast(color2);
-		if (contrastRatio >= 7.1) {
+		if (contrastRatio >= 7.0) {
 			return 'AAA';
 		}
 


### PR DESCRIPTION
Changed the enhanced contrast ratio in the level function from `7.1` to `7.0` as defined by the WCAG 2.1 spec.

it could have been confused due to the ratio being stated as `7:1` but that is equal to `7.0` not `7.1`

https://www.w3.org/TR/WCAG21/#contrast-enhanced