### PR TITLE
chore: bump color-string dep to 1.5.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "color-convert": "^1.9.1",
-    "color-string": "^1.5.4"
+    "color-string": "^1.5.5"
   },
   "devDependencies": {
     "mocha": "^6.1.4",


### PR DESCRIPTION
This bump will ensure using the version of color-string that has this https://github.com/Qix-/color-string/commit/0789e21284c33d89ebc4ab4ca6f759b9375ac9d3 fix included.