### PR TITLE
Remove unnecessary step with number separator from Color function

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,7 +63,6 @@ function Color(object, model) {
 		this.valpha = typeof object[channels] === 'number' ? object[channels] : 1;
 	} else if (typeof object === 'number') {
 		// This is always RGB - can be converted later on.
-		object &= 0xFF_FF_FF;
 		this.model = 'rgb';
 		this.color = [
 			(object >> 16) & 0xFF,


### PR DESCRIPTION
@Qix- I'm sorry that my comment https://github.com/Qix-/color/issues/204#issuecomment-889933878 came across as demanding and thankless. I'll try to be more constructive and look for a solution that is aligned with your aims of this project. What do you think about the change in this PR? Unlike transpiling, it should AFAIK not add any maintenance cost. 

AFAIK `object &= 0xFF_FF_FF;` was an unnecessary step, because

`object & 0xFF` is equivalent to `object & 0xFF_FF_FF & 0xFF` and
`(object >> 16) & 0xFF` is equivalent to `((object & 0xFF_FF_FF) >> 16) & 0xFF`

This should prevent the error described in https://github.com/Qix-/color/issues/204

There is just one more place that would throw a similar error: https://github.com/Qix-/color/blob/694d1975a93c5981c2809da8a72678c16223ad0d/index.js#L257 I want to try to find a mutually acceptable solution for that one as well, but first I want to know if this solution is acceptable, or there is still something more I didn't consider? 

Note that I don't have anything against ESM. I have read through https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c that you recommended and I didn't find there anything about ECMAScript 2021 features (such as Numeric separators). I'm using ESM in my code that is built/compiled with https://cli.vuejs.org/. It also works well with ESM in NPM dependencies that use the `package.json` `module` field. The only thing that is causing issues is ES2021 numeric separators.