### PR TITLE
restrict node version to ">=12.5.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,9 @@
     "pretest": "xo",
     "test": "mocha"
   },
+  "engines": {
+    "node": ">=12.5.0"
+  },
   "dependencies": {
     "color-convert": "^2.0.1",
     "color-string": "^1.9.0"


### PR DESCRIPTION
Add the "engines" entry to package.json to make node aware of the incompatibility due to Numeric Separators used in this
code base, which are supported since NodeJS v12.5.0.

I know, you might not care, as NodeJS v12 is the LTS anyway, but it's always better to be explicit in case someone uses an outdated NodeJS version.