### PR TITLE
add rgba to hex support

### DIFF
--- a/index.js
+++ b/index.js
@@ -242,6 +242,21 @@ Color.prototype = {
 		return colorString.to.hex(this.rgb().round().color);
 	},
 
+	hexa(value) {
+		if (arguments.length > 0) {
+			return new Color(value);
+		}
+
+		const rgbArray = this.rgb().round().color;
+
+		let alphaHex = Math.round(this.valpha * 255).toString(16).toUpperCase();
+		if (alphaHex.length === 1) {
+			alphaHex = '0' + alphaHex;
+		}
+
+		return colorString.to.hex(rgbArray) + alphaHex;
+	},
+
 	rgbNumber() {
 		const rgb = this.rgb().color;
 		return ((rgb[0] & 0xFF) << 16) | ((rgb[1] & 0xFF) << 8) | (rgb[2] & 0xFF);

--- a/test/index.js
+++ b/test/index.js
@@ -512,6 +512,10 @@ it('Translate with channel setters', () => {
 
 it('CSS String getters', () => {
 	equal(Color('rgb(10, 30, 25)').hex(), '#0A1E19');
+	equal(Color('rgb(10, 30, 25, 1)').hexa(), '#0A1E19FF');
+	equal(Color('rgb(10, 30, 25, 0.4)').hexa(), '#0A1E1966');
+	equal(Color('rgb(10, 30, 25, 0)').hexa(), '#0A1E1900');
+	equal(Color('rgb(10, 30, 25, 0.01)').hexa(), '#0A1E1903');
 	equal(Color('rgb(10, 30, 25)').rgb().string(), 'rgb(10, 30, 25)');
 	equal(Color('rgb(10, 30, 25, 0.4)').rgb().string(), 'rgba(10, 30, 25, 0.4)');
 	equal(Color('rgb(10, 30, 25)').percentString(), 'rgb(4%, 12%, 10%)');


### PR DESCRIPTION
Currently the `hex` converter simply ignores the `alpha` value if the color is of `rgba` format. The PR resolves the issue.

Related to [Do we already have argb hex string converter](https://github.com/Qix-/color/issues/72)