### PR TITLE
fix: build fails when environment does not support numeric separators

### DIFF
--- a/index.js
+++ b/index.js
@@ -269,7 +269,7 @@ Color.prototype = {
 		const lum = [];
 		for (const [i, element] of rgb.entries()) {
 			const chan = element / 255;
-			lum[i] = (chan <= 0.039_28) ? chan / 12.92 : ((chan + 0.055) / 1.055) ** 2.4;
+			lum[i] = (chan <= 0.03928) ? chan / 12.92 : ((chan + 0.055) / 1.055) ** 2.4;
 		}
 
 		return 0.2126 * lum[0] + 0.7152 * lum[1] + 0.0722 * lum[2];


### PR DESCRIPTION
I was kind of surprised that some setups still do not support numeric separators and i did not expect to run into this, but I did (in case of storybook/react)

Given the vast amount of issues that get closed and locked (so people could not actually help each other providing solutions), i think its just pragmatic to remove the one (!) usage of the numeric separator.